### PR TITLE
Add import, export ease factors

### DIFF
--- a/reset_ease.py
+++ b/reset_ease.py
@@ -15,8 +15,34 @@ def reset_ease():
             card.factor = user_ease_to_ease(user_ease)
             card.flush()
 
+
+def store_ease(deck_name):
+    '''For some deck `deck_name`, returns a dictionary linking card id keys to
+    ease factors.
+    '''
+    ease_backup = {}
+    card_ids = mw.col.find_cards(f'deck:"{deck_name}"')
+    for card_id in card_ids:
+        card = mw.col.getCard(card_id)
+        ease_backup[card_id] = card.factor
+    return ease_backup
+
+
+def restore_ease(deck_name, backup):
+    '''For deck `deck_name` and `backup`--a dictionary linking card id keys to
+    ease factors--set the ease factors of the cards in the deck to the ease
+    factors provided in `backup`.
+    '''
+    card_ids = mw.col.find_cards(f'deck:"{deck_name}"')
+    for card_id in card_ids:
+        card = mw.col.getCard(card_id)
+        card.factor = backup.get(card_id, card.factor)
+        card.flush()
+
+
 def user_ease_to_ease(user_ease):
     return user_ease * 10
+
 
 def deck_id(deck_name):
     return DeckManager(mw.col).id_for_name(deck_name)

--- a/reset_ease.py
+++ b/reset_ease.py
@@ -1,8 +1,11 @@
 from anki.decks import DeckManager
 from aqt import mw
-
 from .config import get_value
-
+from aqt.gui_hooks import deck_browser_will_show_options_menu
+from aqt.utils import getFile, getSaveFile
+import datetime
+from anki.lang import _
+from ast import literal_eval
 
 def reset_ease():
     deck_to_user_ease = get_value("deck_to_ease")
@@ -16,27 +19,54 @@ def reset_ease():
             card.flush()
 
 
-def store_ease(deck_name):
-    '''For some deck `deck_name`, returns a dictionary linking card id keys to
+def export_ease_factors(deck_id):
+    '''For some deck `deck_id`, returns a dictionary linking card id keys to
     ease factors.
     '''
-    ease_backup = {}
+    deck_name = mw.col.decks.nameOrNone(deck_id)
+    if deck_name is None:
+        return
+    
+    # open file picker to store factors
+    dt_now_str = str(datetime.datetime.now().strftime("%Y%m%d-%H%M%S"))
+    suggested_filename = "ease_factors_" + str(deck_id) + dt_now_str
+    export_file = getSaveFile(mw, _("Export"), "export", 
+                              key = "",
+                              ext = "",
+                              fname=suggested_filename)
+    if not export_file:
+        return
+
+    factors = {}
     card_ids = mw.col.find_cards(f'deck:"{deck_name}"')
     for card_id in card_ids:
         card = mw.col.getCard(card_id)
-        ease_backup[card_id] = card.factor
-    return ease_backup
+        factors[card_id] = card.factor
+    with open(export_file, 'w') as export_file_object: 
+         export_file_object.write(str(factors))
 
 
-def restore_ease(deck_name, backup):
-    '''For deck `deck_name` and `backup`--a dictionary linking card id keys to
+def import_ease_factors(deck_id, factors=None):
+    '''For deck `deck_id` and `factors`--a dictionary linking card id keys to
     ease factors--set the ease factors of the cards in the deck to the ease
-    factors provided in `backup`.
+    factors provided in `factors`.
     '''
+    deck_name = mw.col.decks.nameOrNone(deck_id)
+    if deck_name is None:
+        print("Deck name not found on import_ease_factors, exiting...")
+        return
+    
+    if factors is None:
+        # open file picker to load factors
+        import_file = getFile(mw, _("Import"), None, 
+                              key = "import")
+        with open(import_file, 'r') as import_file_object:
+            factors = literal_eval(import_file_object.read())
+        
     card_ids = mw.col.find_cards(f'deck:"{deck_name}"')
     for card_id in card_ids:
         card = mw.col.getCard(card_id)
-        card.factor = backup.get(card_id, card.factor)
+        card.factor = factors.get(card_id, card.factor)
         card.flush()
 
 
@@ -46,3 +76,15 @@ def user_ease_to_ease(user_ease):
 
 def deck_id(deck_name):
     return DeckManager(mw.col).id_for_name(deck_name)
+
+
+def add_deck_options(menu, deck_id):
+    export_action = menu.addAction("Export Ease Factors")
+    export_action.triggered.connect(lambda _,
+                                    did=deck_id: export_ease_factors(did))
+    import_action = menu.addAction("Import Ease Factors")
+    import_action.triggered.connect(lambda _,
+                                    did=deck_id: import_ease_factors(did))
+
+
+deck_browser_will_show_options_menu.append(add_deck_options)


### PR DESCRIPTION
This adds the ability to import and export ease factors through the deck settings menu.

It's the most basic implementation, and might benefit from some refining, like additional confirmation dialogs, smarter default file paths (maybe use the add-on folder?), validating the contents of imported files, and generalizing to support importing/exporting for multiple decks at once.

But this has the basics covered as a start, you can prioritize what to tweak from here.

Testing:
1. Use the deck settings menu and select "Export ease factors"
2. After saving, open that file in a text editor and change an ease setting to 9999 or something noticeable and save.
3. Use the deck settings to "Import ease factors" on that same file.
4. Use the browser to sort that deck by ease. (You may have to get the card's info if it's considered "(New)" to confirm.